### PR TITLE
Check use secrets for additional parameters

### DIFF
--- a/src/FeatureBits.Console/FeatureBits.Console.csproj
+++ b/src/FeatureBits.Console/FeatureBits.Console.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Version>0.1.0</Version>
@@ -15,6 +15,7 @@
     <PackageReference Include="CommandLineParser" Version="2.2.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.0.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.0.2" />
     <PackageReference Include="System.Data.SqlClient" Version="4.4.3" />
     <PackageReference Include="System.IO.Abstractions" Version="2.1.0.178" />
   </ItemGroup>

--- a/src/FeatureBits.Console/ProjectFileHelper.cs
+++ b/src/FeatureBits.Console/ProjectFileHelper.cs
@@ -1,0 +1,106 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.IO.Abstractions;
+
+namespace Dotnet.FBit
+{
+    public static class ProjectFileHelper
+    {
+        public static IFileSystem FileSystem { get; set; } = new FileSystem();
+
+        public static string GetDefaultNamespace(DirectoryInfoBase directory)
+        {
+            FileInfoBase[] fileInfos = FindAllCsprojFiles(directory);
+            FileInfoBase fileToSearch = ChooseCsproj(fileInfos);
+            return GetNamespaceFromCsproj(fileToSearch);
+        }
+
+        public static string GetUserSecretsId(string directory)
+        {
+            try
+            {
+                FileInfoBase[] fileInfos = FindAllCsprojFiles(FileSystem.DirectoryInfo.FromDirectoryName(directory));
+                FileInfoBase fileToSearch = ChooseCsproj(fileInfos);
+                return GetUserSecretsIdFromProject(fileToSearch);
+            }
+            catch (FileNotFoundException)
+            {
+                return string.Empty;
+            }
+        }
+
+        private static string GetUserSecretsIdFromProject(FileInfoBase fileToSearch)
+        {
+            string openingTag = "<UserSecretsId>";
+            string closingTag = "</UserSecretsId>";
+            string userSecretsId = string.Empty;
+            using (Stream fr = fileToSearch.OpenRead())
+            {
+                StreamReader sr = new StreamReader(fr);
+                string fileContents = sr.ReadToEnd();
+                int openingIndex = fileContents.IndexOf(openingTag, StringComparison.OrdinalIgnoreCase);
+                if (openingIndex > -1)
+                {
+                    int closingIndex = fileContents.IndexOf(closingTag, openingIndex + openingTag.Length, StringComparison.OrdinalIgnoreCase);
+                    int substringStartingIndex = openingIndex + openingTag.Length;
+                    userSecretsId = fileContents.Substring(substringStartingIndex, closingIndex - substringStartingIndex);
+                }
+            }
+
+            return userSecretsId;
+        }
+
+        private static FileInfoBase[] FindAllCsprojFiles(DirectoryInfoBase directory)
+        {
+            FileInfoBase[] fileInfos = directory.GetFiles("*.csproj", SearchOption.TopDirectoryOnly);
+            if (fileInfos.Length == 0)
+            {
+                SystemContext.ConsoleErrorWriteLine("No csproj file found for default namespace. Please specify a namespace as a command argument.");
+                throw new FileNotFoundException();
+            }
+
+            return fileInfos;
+        }
+
+        private static FileInfoBase ChooseCsproj(FileInfoBase[] fileInfos)
+        {
+            if (fileInfos.Length > 1)
+            {
+                SystemContext.ConsoleWriteLine("Multiple csproj files found for namespace, using the first one.");
+            }
+
+            FileInfoBase fileToSearch = fileInfos[0];
+            return fileToSearch;
+        }
+
+        private static string GetNamespaceFromCsproj(FileInfoBase fileToSearch)
+        {
+            string nameSpace;
+            using (Stream fr = fileToSearch.OpenRead())
+            {
+                StreamReader sr = new StreamReader(fr);
+                string fileContents = sr.ReadToEnd();
+
+                // Look for a <RootNamespace> tag
+                string openingTag = "<RootNamespace>";
+                string closingTag = "</RootNamespace>";
+                int openingIndex = fileContents.IndexOf(openingTag, StringComparison.OrdinalIgnoreCase);
+                if (openingIndex > -1)
+                {
+                    int closingIndex = fileContents.IndexOf(closingTag, openingIndex + openingTag.Length, StringComparison.OrdinalIgnoreCase);
+                    int substringStartingIndex = openingIndex + openingTag.Length;
+                    nameSpace = fileContents.Substring(substringStartingIndex, closingIndex - substringStartingIndex);
+                }
+                else
+                {
+                    nameSpace = FileSystem.Path.GetFileNameWithoutExtension(fileToSearch.Name);
+                }
+            }
+
+            return nameSpace;
+        }
+    }
+}

--- a/test/FeatureBits.Console.Test/FeatureBits.Console.Test.csproj
+++ b/test/FeatureBits.Console.Test/FeatureBits.Console.Test.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.3.0" />
+    <PackageReference Include="FluentAssertions" Version="5.3.2" />
     <PackageReference Include="Microsoft.CodeCoverage" Version="1.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />

--- a/test/FeatureBits.Console.Test/GenerateCommandTests.cs
+++ b/test/FeatureBits.Console.Test/GenerateCommandTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Abstractions;
@@ -26,7 +25,6 @@ namespace FeatureBits.Console.Test
             new CommandFeatureBitDefintion {Name = "bat", Id = 3},
         };
 
-        
         [Fact]
         public void It_can_be_created()
         {
@@ -107,88 +105,6 @@ namespace FeatureBits.Console.Test
             // Assert
             result.Should().BeFalse();
             sb.ToString().Should().Be("Output file already exists.");
-        }
-
-        [Fact]
-        public void It_throws_FileNotFoundException_if_GetDefaultNamespace_cannot_find_csproj()
-        {
-            // Arrange
-            var opts = new GenerateOptions();
-
-            // Arrange Mocks
-            var sb = new StringBuilder();
-            SystemContext.ConsoleErrorWriteLine = s => sb.Append(s);
-            var repo = Substitute.For<IFeatureBitsRepo>();
-            var filesystem = Substitute.For<IFileSystem>();
-            var directory = Substitute.For<DirectoryInfoBase>();
-            directory.GetFiles("*.csproj", SearchOption.TopDirectoryOnly).Returns(info => new FileInfoBase[] { });
-
-            // Arrange IT
-            var it = new GenerateCommand(opts, repo, filesystem);
-
-            // Act
-            Action act = () => it.GetDefaultNamespace(directory);
-            
-
-            // Assert
-            act.Should().Throw<FileNotFoundException>();
-            sb.ToString().Should().Be("No csproj file found for default namespace. Please specify a namespace as a command argument.");
-        }
-
-        [Fact]
-        public void It_can_GetDefaultNamespace_even_if_it_finds_too_many_csproj_files()
-        {
-            // Arrange
-            var opts = new GenerateOptions();
-
-            // Arrange Mocks
-            var sb = new StringBuilder();
-            SystemContext.ConsoleWriteLine = s => sb.Append(s);
-            var repo = Substitute.For<IFeatureBitsRepo>();
-            var filesystem = Substitute.For<IFileSystem>();
-            var directory = Substitute.For<DirectoryInfoBase>();
-            var result1 = Substitute.For<FileInfoBase>();
-            var result2 = Substitute.For<FileInfoBase>();
-            var filecontent = "<RootNamespace>Foo</RootNamespace>";
-            directory.GetFiles("*.csproj", SearchOption.TopDirectoryOnly).Returns(info => new[] { result1, result2 });
-            result1.OpenRead().Returns(info => StringToStream(filecontent));
-
-            // Arrange IT
-            var it = new GenerateCommand(opts, repo, filesystem);
-
-            // Act
-            var result = it.GetDefaultNamespace(directory);
-
-            // Assert
-            result.Should().Be("Foo");
-            sb.ToString().Should().Be("Multiple csproj files found for namespace, using the first one.");
-        }
-
-        [Fact]
-        public void It_can_GetDefaultNamespace_even_if_the_rootNamespace_is_not_found_in_csproj()
-        {
-            // Arrange
-            var opts = new GenerateOptions();
-
-            // Arrange Mocks
-            var repo = Substitute.For<IFeatureBitsRepo>();
-            var filesystem = Substitute.For<IFileSystem>();
-            var directory = Substitute.For<DirectoryInfoBase>();
-            var result1 = Substitute.For<FileInfoBase>();
-            var filecontent = "Sorry no namespace here";
-            directory.GetFiles("*.csproj", SearchOption.TopDirectoryOnly).Returns(info => new[] { result1  });
-            result1.OpenRead().Returns(info => StringToStream(filecontent));
-            result1.Name.Returns("bar.csproj");
-            filesystem.Path.GetFileNameWithoutExtension("bar.csproj").Returns("bar");
-
-            // Arrange IT
-            var it = new GenerateCommand(opts, repo, filesystem);
-
-            // Act
-            var result = it.GetDefaultNamespace(directory);
-
-            // Assert
-            result.Should().Be("bar");
         }
 
         [Fact]
@@ -311,6 +227,5 @@ namespace FeatureBits.Console.Test
             stream.Position = 0;
             return stream;
         }
-
     }
 }

--- a/test/FeatureBits.Console.Test/ProjectFileHelperTests.cs
+++ b/test/FeatureBits.Console.Test/ProjectFileHelperTests.cs
@@ -1,0 +1,85 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.IO.Abstractions;
+using System.Text;
+using Dotnet.FBit;
+using FluentAssertions;
+using NSubstitute;
+using Xunit;
+
+namespace FeatureBits.Console.Test
+{
+    public class ProjectFileHelperTests
+    {
+        [Fact]
+        public void It_throws_FileNotFoundException_if_GetDefaultNamespace_cannot_find_csproj()
+        {
+            // Arrange Mocks
+            var sb = new StringBuilder();
+            SystemContext.ConsoleErrorWriteLine = s => sb.Append(s);
+            var directory = Substitute.For<DirectoryInfoBase>();
+            directory.GetFiles("*.csproj", SearchOption.TopDirectoryOnly).Returns(info => new FileInfoBase[] { });
+            
+            // Act
+            Action act = () => ProjectFileHelper.GetDefaultNamespace(directory);
+
+            // Assert
+            act.Should().Throw<FileNotFoundException>();
+            sb.ToString().Should().Be("No csproj file found for default namespace. Please specify a namespace as a command argument.");
+        }
+
+        [Fact]
+        public void It_can_GetDefaultNamespace_even_if_it_finds_too_many_csproj_files()
+        {
+            // Arrange Mocks
+            var sb = new StringBuilder();
+            SystemContext.ConsoleWriteLine = s => sb.Append(s);
+            var directory = Substitute.For<DirectoryInfoBase>();
+            var result1 = Substitute.For<FileInfoBase>();
+            var result2 = Substitute.For<FileInfoBase>();
+            var filecontent = "<RootNamespace>Foo</RootNamespace>";
+            directory.GetFiles("*.csproj", SearchOption.TopDirectoryOnly).Returns(info => new[] { result1, result2 });
+            result1.OpenRead().Returns(info => StringToStream(filecontent));
+
+            // Act
+            var result = ProjectFileHelper.GetDefaultNamespace(directory);
+
+            // Assert
+            result.Should().Be("Foo");
+            sb.ToString().Should().Be("Multiple csproj files found for namespace, using the first one.");
+        }
+
+        [Fact]
+        public void It_can_GetDefaultNamespace_even_if_the_rootNamespace_is_not_found_in_csproj()
+        {
+            // Arrange Mocks
+            var filesystem = Substitute.For<IFileSystem>();
+            var directory = Substitute.For<DirectoryInfoBase>();
+            var result1 = Substitute.For<FileInfoBase>();
+            var filecontent = "Sorry no namespace here";
+            directory.GetFiles("*.csproj", SearchOption.TopDirectoryOnly).Returns(info => new[] { result1 });
+            result1.OpenRead().Returns(info => StringToStream(filecontent));
+            result1.Name.Returns("bar.csproj");
+            filesystem.Path.GetFileNameWithoutExtension("bar.csproj").Returns("bar");
+
+            // Act
+            var result = ProjectFileHelper.GetDefaultNamespace(directory);
+
+            // Assert
+            result.Should().Be("bar");
+        }
+
+        private static Stream StringToStream(string stringToStream)
+        {
+            var stream = new MemoryStream();
+            var writer = new StreamWriter(stream);
+            writer.Write(stringToStream);
+            writer.Flush();
+            stream.Position = 0;
+            return stream;
+        }
+    }
+}


### PR DESCRIPTION
Can now set a variable in the user secrets of a project that references the fbit nuget. An example of this is a source database connection string:

"fbit:-s": "Data Source=..."