### PR TITLE
Renamed EF Table to match other migration and class used by EF.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,47 @@
+# https://www.appveyor.com/docs/appveyor-yml/
+#---------------------------------#
+#      general configuration      #
+#---------------------------------#
+
+# version format
+version: '0.1.{build}'          
+
+#---------------------------------#
+#    environment configuration    #
+#---------------------------------#
+
+# Build worker image (VM template)
+image: Visual Studio 2017
+
+#---------------------------------#
+#       build configuration       #
+#---------------------------------#
+# build platform, i.e. x86, x64, Any CPU. This setting is optional.
+platform: Any CPU
+
+# build Configuration, i.e. Debug, Release, etc.
+configuration: Debug
+
+before_build:
+- cmd: set ASPNETCORE_ENVIRONMENT=LocalDevelopment
+- cmd: dotnet restore
+
+build:
+  # enable MSBuild parallel builds
+  parallel: true   
+  # path to Visual Studio solution or project               
+  project: FeatureBits.sln      
+  # MSBuild verbosity level
+  verbosity: minimal
+
+#---------------------------------#
+#       tests configuration       #
+#---------------------------------#
+
+#---------------------------------#
+#      artifacts configuration    #
+#---------------------------------#
+
+#---------------------------------#
+#     deployment configuration    #
+#---------------------------------#

--- a/src/FeatureBits.Data/Migrations/20180424182241_Initial-Create.cs
+++ b/src/FeatureBits.Data/Migrations/20180424182241_Initial-Create.cs
@@ -10,7 +10,7 @@ namespace FeatureBitsData.Migrations
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.CreateTable(
-                name: "IFeatureBitDefinitions",
+                name: "FeatureBitDefinitions",
                 columns: table => new
                 {
                     Id = table.Column<int>(nullable: false)
@@ -27,14 +27,14 @@ namespace FeatureBitsData.Migrations
                 },
                 constraints: table =>
                 {
-                    table.PrimaryKey("PK_IFeatureBitDefinitions", x => x.Id);
+                    table.PrimaryKey("PK_FeatureBitDefinitions", x => x.Id);
                 });
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.DropTable(
-                name: "IFeatureBitDefinitions");
+                name: "FeatureBitDefinitions");
         }
     }
 }


### PR DESCRIPTION
The Migrations didn't match for the database table name and the "I" prefix caused the DbSet to fail when connecting to the database.