### PR TITLE
Fixed #20

### DIFF
--- a/src/FeatureBits.Console/Command/AddCommand.cs
+++ b/src/FeatureBits.Console/Command/AddCommand.cs
@@ -5,6 +5,7 @@ using System;
 using System.Data;
 using System.Threading.Tasks;
 using Dotnet.FBit.CommandOptions;
+using FeatureBits.Core;
 using FeatureBits.Data;
 
 namespace Dotnet.FBit.Command

--- a/src/FeatureBits.Console/Command/GenerateCommand.cs
+++ b/src/FeatureBits.Console/Command/GenerateCommand.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Dotnet.FBit.CommandOptions;
+using FeatureBits.Core;
 using FeatureBits.Data;
 
 namespace Dotnet.FBit.Command
@@ -80,7 +81,7 @@ namespace Dotnet.FBit.Command
             return returnValue;
         }
 
-        private void WriteFileContent(IEnumerable<(string Name, int Id)> featureBitData, string fileNamespace, 
+        private void WriteFileContent(IEnumerable<(string Name, int Id)> featureBitData, string fileNamespace,
             FileInfoBase outputFile)
         {
             const string headerInfoFormat = @"
@@ -95,9 +96,9 @@ namespace {0}
 }";
 
             FileContent.AppendLine(string.Format(headerInfoFormat, fileNamespace));
-            foreach (var featureBit in featureBitData)
+            foreach (var (name, id) in featureBitData)
             {
-                FileContent.AppendLine($"        {featureBit.Name} = {featureBit.Id},");
+                FileContent.AppendLine($"        {name} = {id},");
             }
 
             FileContent.AppendLine(tailInfo);

--- a/src/FeatureBits.Console/Command/RemoveCommand.cs
+++ b/src/FeatureBits.Console/Command/RemoveCommand.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading.Tasks;
 using Dotnet.FBit.CommandOptions;
+using FeatureBits.Core;
 using FeatureBits.Data;
 
 namespace Dotnet.FBit.Command

--- a/src/FeatureBits.Console/FeatureBits.Console.csproj
+++ b/src/FeatureBits.Console/FeatureBits.Console.csproj
@@ -31,6 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\FeatureBits.Core\FeatureBits.Core.csproj" />
     <ProjectReference Include="..\FeatureBits.Data\FeatureBits.Data.csproj" />
   </ItemGroup>
 </Project>

--- a/src/FeatureBits.Console/ProjectFileHelper.cs
+++ b/src/FeatureBits.Console/ProjectFileHelper.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.IO.Abstractions;
+using FeatureBits.Core;
 
 namespace Dotnet.FBit
 {

--- a/src/FeatureBits.Core/SystemContext.cs
+++ b/src/FeatureBits.Core/SystemContext.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace Dotnet.FBit
+namespace FeatureBits.Core
 {
     public static class SystemContext
     {

--- a/test/FeatureBits.Console.Test/AddCommandTests.cs
+++ b/test/FeatureBits.Console.Test/AddCommandTests.cs
@@ -7,9 +7,9 @@ using System.ComponentModel.DataAnnotations;
 using System.Data;
 using System.Text;
 using System.Threading.Tasks;
-using Dotnet.FBit;
 using Dotnet.FBit.Command;
 using Dotnet.FBit.CommandOptions;
+using FeatureBits.Core;
 using FeatureBits.Data;
 using FluentAssertions;
 using NSubstitute;
@@ -54,11 +54,11 @@ namespace FeatureBits.Console.Test
             // Arrange
             var sb = new StringBuilder();
             SystemContext.ConsoleWriteLine = s => sb.Append(s);
-            var bit = new CommandFeatureBitDefintion {Name = "foo"};
-            var opts = new AddOptions{Name = "foo"};
+            var bit = new CommandFeatureBitDefintion { Name = "foo" };
+            var opts = new AddOptions { Name = "foo" };
             var repo = Substitute.For<IFeatureBitsRepo>();
             repo.AddAsync(bit).Returns(Task.FromResult((IFeatureBitDefinition)bit));
-            
+
             var it = new AddCommand(opts, repo);
 
             // Act
@@ -76,14 +76,14 @@ namespace FeatureBits.Console.Test
             CommandFeatureBitDefintion def = null;
             var sb = new StringBuilder();
             SystemContext.ConsoleWriteLine = s => sb.Append(s);
-            var bit = new CommandFeatureBitDefintion {Name = "foo", OnOff = false};
-            var opts = new AddOptions{Name = "foo", OnOff = "false"};
+            var bit = new CommandFeatureBitDefintion { Name = "foo", OnOff = false };
+            var opts = new AddOptions { Name = "foo", OnOff = "false" };
             var repo = Substitute.For<IFeatureBitsRepo>();
             repo.AddAsync(Arg.Any<CommandFeatureBitDefintion>()).Returns(Task.FromResult((IFeatureBitDefinition)bit)).AndDoes(x =>
             {
                 def = x.Arg<CommandFeatureBitDefintion>();
             });
-            
+
             var it = new AddCommand(opts, repo);
 
             // Act
@@ -102,10 +102,10 @@ namespace FeatureBits.Console.Test
             // Arrange
             var sb = new StringBuilder();
             SystemContext.ConsoleErrorWriteLine = s => sb.Append(s);
-            var opts = new AddOptions{Name = "foo"};
+            var opts = new AddOptions { Name = "foo" };
             var repo = Substitute.For<IFeatureBitsRepo>();
             repo.AddAsync(Arg.Any<IFeatureBitDefinition>()).Returns<Task<IFeatureBitDefinition>>(x => throw new Exception("Yow!"));
-            
+
             var it = new AddCommand(opts, repo);
 
             // Act
@@ -134,7 +134,7 @@ namespace FeatureBits.Console.Test
                 MinimumPermissionLevel = 20
             };
             var repo = Substitute.For<IFeatureBitsRepo>();
-            
+
             var it = new AddCommand(opts, repo);
 
             // Act
@@ -156,7 +156,7 @@ namespace FeatureBits.Console.Test
             // Arrange
             var sb = new StringBuilder();
             SystemContext.ConsoleErrorWriteLine = s => sb.Append(s);
-            var opts = new AddOptions{Name = "foo"};
+            var opts = new AddOptions { Name = "foo" };
             var repo = Substitute.For<IFeatureBitsRepo>();
             repo.AddAsync(Arg.Any<IFeatureBitDefinition>()).Returns<Task<IFeatureBitDefinition>>(x => throw new DataException("Cannot add. Feature bit with name 'foo' already exists."));
 
@@ -176,7 +176,7 @@ namespace FeatureBits.Console.Test
             // Arrange
             var sb = new StringBuilder();
             SystemContext.ConsoleErrorWriteLine = s => sb.Append(s);
-            var opts = new AddOptions{Name = "foo"};
+            var opts = new AddOptions { Name = "foo" };
             var repo = Substitute.For<IFeatureBitsRepo>();
             repo.AddAsync(Arg.Any<IFeatureBitDefinition>()).Returns<Task<IFeatureBitDefinition>>(x => throw new DataException("Some random DataException."));
 
@@ -196,13 +196,13 @@ namespace FeatureBits.Console.Test
             // Arrange
             var sb = new StringBuilder();
             SystemContext.ConsoleWriteLine = s => sb.Append(s);
-            var opts = new AddOptions{Name = "foo", Force = true};
+            var opts = new AddOptions { Name = "foo", Force = true };
             var repo = Substitute.For<IFeatureBitsRepo>();
             repo.AddAsync(Arg.Any<IFeatureBitDefinition>()).Returns<Task<IFeatureBitDefinition>>(x => throw new DataException("Cannot add. Feature bit with name 'foo' already exists."));
 
             int counter = 0;
             repo.When(x => x.UpdateAsync(Arg.Any<IFeatureBitDefinition>())).Do((x => counter++));
-            
+
             var it = new AddCommand(opts, repo);
 
             // Act

--- a/test/FeatureBits.Console.Test/GenerateCommandTests.cs
+++ b/test/FeatureBits.Console.Test/GenerateCommandTests.cs
@@ -7,9 +7,9 @@ using System.IO.Abstractions;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Dotnet.FBit;
 using Dotnet.FBit.Command;
 using Dotnet.FBit.CommandOptions;
+using FeatureBits.Core;
 using FeatureBits.Data;
 using FluentAssertions;
 using NSubstitute;
@@ -61,7 +61,7 @@ namespace FeatureBits.Console.Test
             result[2].Id.Should().Be(3);
         }
 
-        
+
         [Fact]
         public void It_can_GetOutpuFileInfo()
         {
@@ -79,7 +79,7 @@ namespace FeatureBits.Console.Test
 
             // Assert
             result.Should().NotBeNull();
-            
+
         }
 
         [Fact]
@@ -151,7 +151,7 @@ namespace FeatureBits.Console.Test
                 var outputFile = Substitute.For<FileInfoBase>();
 
                 filesystem.FileInfo.FromFileName(Arg.Any<string>()).Returns(outputFile);
-                directory.GetFiles("*.csproj", SearchOption.TopDirectoryOnly).Returns(info => new[] {csprojFile});
+                directory.GetFiles("*.csproj", SearchOption.TopDirectoryOnly).Returns(info => new[] { csprojFile });
                 csprojFile.OpenRead().Returns(info => StringToStream("Sorry no namespace here"));
                 csprojFile.Name.Returns("bar.csproj");
                 filesystem.Path.GetFileNameWithoutExtension("bar.csproj").Returns("bar");
@@ -160,7 +160,7 @@ namespace FeatureBits.Console.Test
                 outputFile.FullName.Returns("Features.cs");
                 // ReSharper disable once AccessToDisposedClosure
                 outputFile.CreateText().Returns(info => new StreamWriter(ms));
-            
+
 
                 // Arrange IT
                 var it = new GenerateCommand(opts, repo, filesystem);
@@ -194,7 +194,7 @@ namespace FeatureBits.Console.Test
 
                 repo.GetAllAsync().Returns(_featureBitDefinitions);
                 filesystem.FileInfo.FromFileName(Arg.Any<string>()).Returns(outputFile);
-                directory.GetFiles("*.csproj", SearchOption.TopDirectoryOnly).Returns(info => new[] {csprojFile});
+                directory.GetFiles("*.csproj", SearchOption.TopDirectoryOnly).Returns(info => new[] { csprojFile });
                 csprojFile.OpenRead().Returns(info => StringToStream("Sorry no namespace here"));
                 csprojFile.Name.Returns("bar.csproj");
                 filesystem.Path.GetFileNameWithoutExtension("bar.csproj").Returns("bar");
@@ -203,7 +203,7 @@ namespace FeatureBits.Console.Test
                 outputFile.FullName.Returns("Features.cs");
                 // ReSharper disable once AccessToDisposedClosure
                 outputFile.CreateText().Returns(info => new StreamWriter(ms));
-            
+
 
                 // Arrange IT
                 var it = new GenerateCommand(opts, repo, filesystem);

--- a/test/FeatureBits.Console.Test/ListCommandTests.cs
+++ b/test/FeatureBits.Console.Test/ListCommandTests.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.Text;
 using System.Threading.Tasks;
+using FeatureBits.Core;
 using Xunit;
 
 namespace FeatureBits.Console.Test
@@ -25,13 +26,11 @@ namespace FeatureBits.Console.Test
             SystemContext.ConsoleWriteLine = s => sb.AppendLine(s);
             var bit1 = new CommandFeatureBitDefintion { Id = 1, Name = "foo1" };
             var bit2 = new CommandFeatureBitDefintion { Id = 1, Name = "foo2" };
-            var opts = new ListOptions {  };
+            var opts = new ListOptions();
             var repo = Substitute.For<IFeatureBitsRepo>();
             var consoleTable = Substitute.For<IConsoleTable>();
-            var fbits = new List<IFeatureBitDefinition>();
+            var fbits = new List<IFeatureBitDefinition> { bit1, bit2 };
 
-            fbits.Add(bit1);
-            fbits.Add(bit2);
 
             repo.GetAllAsync().Returns(Task.FromResult((IEnumerable<IFeatureBitDefinition>)fbits));
 
@@ -43,7 +42,7 @@ namespace FeatureBits.Console.Test
             // Assert
             result.Should().Be(0);
 
-            consoleTable.Received().Print(Arg.Is<DataTable>(dt => 
+            consoleTable.Received().Print(Arg.Is<DataTable>(dt =>
                 dt.Rows.Count == 2 &&
                 dt.Columns.Count == 2 &&
                 dt.Columns[0].Caption == "Id" &&
@@ -61,10 +60,8 @@ namespace FeatureBits.Console.Test
             var opts = new ListOptions { Long = true };
             var repo = Substitute.For<IFeatureBitsRepo>();
             var consoleTable = Substitute.For<IConsoleTable>();
-            var fbits = new List<IFeatureBitDefinition>();
+            var fbits = new List<IFeatureBitDefinition> { bit1, bit2 };
 
-            fbits.Add(bit1);
-            fbits.Add(bit2);
 
             repo.GetAllAsync().Returns(Task.FromResult((IEnumerable<IFeatureBitDefinition>)fbits));
 

--- a/test/FeatureBits.Console.Test/ProgramTests.cs
+++ b/test/FeatureBits.Console.Test/ProgramTests.cs
@@ -3,6 +3,7 @@
 
 using System.Text;
 using Dotnet.FBit;
+using FeatureBits.Core;
 using Xunit;
 
 namespace FeatureBits.Console.Test

--- a/test/FeatureBits.Console.Test/ProjectFileHelperTests.cs
+++ b/test/FeatureBits.Console.Test/ProjectFileHelperTests.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.IO.Abstractions;
 using System.Text;
 using Dotnet.FBit;
+using FeatureBits.Core;
 using FluentAssertions;
 using NSubstitute;
 using Xunit;
@@ -22,7 +23,7 @@ namespace FeatureBits.Console.Test
             SystemContext.ConsoleErrorWriteLine = s => sb.Append(s);
             var directory = Substitute.For<DirectoryInfoBase>();
             directory.GetFiles("*.csproj", SearchOption.TopDirectoryOnly).Returns(info => new FileInfoBase[] { });
-            
+
             // Act
             Action act = () => ProjectFileHelper.GetDefaultNamespace(directory);
 

--- a/test/FeatureBits.Console.Test/RemoveCommandTests.cs
+++ b/test/FeatureBits.Console.Test/RemoveCommandTests.cs
@@ -4,9 +4,9 @@
 using System;
 using System.Text;
 using System.Threading.Tasks;
-using Dotnet.FBit;
 using Dotnet.FBit.Command;
 using Dotnet.FBit.CommandOptions;
+using FeatureBits.Core;
 using FeatureBits.Data;
 using FluentAssertions;
 using NSubstitute;
@@ -52,9 +52,9 @@ namespace FeatureBits.Console.Test
             // Arrange
             var sb = new StringBuilder();
             SystemContext.ConsoleWriteLine = s => sb.Append(s);
-            var opts = new RemoveOptions{Name = "foo"};
+            var opts = new RemoveOptions { Name = "foo" };
             var repo = Substitute.For<IFeatureBitsRepo>();
-            repo.GetByNameAsync("foo").Returns(Task.FromResult((IFeatureBitDefinition)new CommandFeatureBitDefintion { Name = "foo", Id = 5}));
+            repo.GetByNameAsync("foo").Returns(Task.FromResult((IFeatureBitDefinition)new CommandFeatureBitDefintion { Name = "foo", Id = 5 }));
             repo.RemoveAsync(Arg.Any<IFeatureBitDefinition>());
             var it = new RemoveCommand(opts, repo);
 
@@ -74,9 +74,9 @@ namespace FeatureBits.Console.Test
             // Arrange
             var sb = new StringBuilder();
             SystemContext.ConsoleErrorWriteLine = s => sb.Append(s);
-            var opts = new RemoveOptions{Name = "foo"};
+            var opts = new RemoveOptions { Name = "foo" };
             var repo = Substitute.For<IFeatureBitsRepo>();
-            repo.GetByNameAsync("foo").Returns(Task.FromResult( (IFeatureBitDefinition) null ));
+            repo.GetByNameAsync("foo").Returns(Task.FromResult((IFeatureBitDefinition)null));
             var it = new RemoveCommand(opts, repo);
 
             // Act

--- a/test/FeatureBits.Core.Test/FeatureBitEvaluatorTests.cs
+++ b/test/FeatureBits.Core.Test/FeatureBitEvaluatorTests.cs
@@ -14,10 +14,10 @@ namespace FeatureBits.Core.Test
     public class FeatureBitEvaluatorTests
     {
         [Fact]
-        public void It_can_evaluate_a_Simple_FeatureBit_to_true() 
+        public void It_can_evaluate_a_Simple_FeatureBit_to_true()
         {
             // Arrange
-            var it = SetupFeatureBitEvaluator(new FeatureBitEfDefinition {Id = 1, OnOff = true});
+            var it = SetupFeatureBitEvaluator(new FeatureBitEfDefinition { Id = 1, OnOff = true });
 
             // Act
             var result = it.IsEnabled(1);
@@ -30,7 +30,7 @@ namespace FeatureBits.Core.Test
         public void It_can_evaluate_a_Simple_FeatureBit_to_false()
         {
             // Arrange
-            var it = SetupFeatureBitEvaluator(new FeatureBitEfDefinition { Id = 0});
+            var it = SetupFeatureBitEvaluator(new FeatureBitEfDefinition { Id = 0 });
 
             // Act
             var result = it.IsEnabled(0);
@@ -43,7 +43,7 @@ namespace FeatureBits.Core.Test
         public void It_throws_when_the_bit_cant_be_found()
         {
             // Arrange
-            var it = SetupFeatureBitEvaluator(new FeatureBitEfDefinition { Id = 10});
+            var it = SetupFeatureBitEvaluator(new FeatureBitEfDefinition { Id = 10 });
 
             // Act / Assert
             Assert.Throws<KeyNotFoundException>(() => { it.IsEnabled(0); });
@@ -54,13 +54,37 @@ namespace FeatureBits.Core.Test
         {
             // Arrange
             // Excluded Environment trumps "OnOff"
-            var it = SetupFeatureBitEvaluator(new FeatureBitEfDefinition { Id = 0, OnOff = true, ExcludedEnvironments = "LocalDevelopment" } );
+            var it = SetupFeatureBitEvaluator(new FeatureBitEfDefinition
+            {
+                Id = 0,
+                OnOff = true,
+                ExcludedEnvironments = "LocalDevelopment,Development,QA"
+            });
 
             // Act
             var result = it.IsEnabled(0);
 
             // Assert
             result.Should().Be(false);
+        }
+
+        [Fact]
+        public void It_can_evaluate_an_Environment_FeatureBit_to_true_if_it_is_not_a_complete_match()
+        {
+            // Arrange
+            // Excluded Environment trumps "OnOff"
+            var it = SetupFeatureBitEvaluator(new FeatureBitEfDefinition
+            {
+                Id = 0,
+                OnOff = true,
+                ExcludedEnvironments = "Development,Production"
+            });
+
+            // Act
+            var result = it.IsEnabled(0);
+
+            // Assert
+            result.Should().Be(true);
         }
 
         [Theory]
@@ -72,7 +96,12 @@ namespace FeatureBits.Core.Test
         {
             // Arrange
             // Excluded Environment trumps "OnOff"
-            var it = SetupFeatureBitEvaluator(new FeatureBitEfDefinition { Id = 0, OnOff = false, MinimumAllowedPermissionLevel = permissionLevel});
+            var it = SetupFeatureBitEvaluator(new FeatureBitEfDefinition
+            {
+                Id = 0,
+                OnOff = false,
+                MinimumAllowedPermissionLevel = permissionLevel
+            });
 
             // Act
             var result = it.IsEnabled(0, permissionLevel);
@@ -86,7 +115,12 @@ namespace FeatureBits.Core.Test
         {
             int userPermission = 30;
             // Arrange
-            var it = SetupFeatureBitEvaluator(new FeatureBitEfDefinition { Id = 0, OnOff = false, ExactAllowedPermissionLevel = 30 });
+            var it = SetupFeatureBitEvaluator(new FeatureBitEfDefinition
+            {
+                Id = 0,
+                OnOff = false,
+                ExactAllowedPermissionLevel = 30
+            });
 
             // Act
             var result = it.IsEnabled(0, userPermission);
@@ -100,7 +134,12 @@ namespace FeatureBits.Core.Test
         {
             int userPermission = 30;
             // Arrange
-            var it = SetupFeatureBitEvaluator(new FeatureBitEfDefinition { Id = 0, OnOff = false, ExactAllowedPermissionLevel = 20 });
+            var it = SetupFeatureBitEvaluator(new FeatureBitEfDefinition
+            {
+                Id = 0,
+                OnOff = false,
+                ExactAllowedPermissionLevel = 20
+            });
 
             // Act
             var result = it.IsEnabled(0, userPermission);
@@ -117,7 +156,12 @@ namespace FeatureBits.Core.Test
         {
             // Arrange
             // Excluded Environment trumps "OnOff"
-            var it = SetupFeatureBitEvaluator(new FeatureBitEfDefinition { Id = 0, OnOff = false, MinimumAllowedPermissionLevel = 30 });
+            var it = SetupFeatureBitEvaluator(new FeatureBitEfDefinition
+            {
+                Id = 0,
+                OnOff = false,
+                MinimumAllowedPermissionLevel = 30
+            });
 
             // Act
             var result = it.IsEnabled(0, permissionLevel);
@@ -132,9 +176,9 @@ namespace FeatureBits.Core.Test
             // Arrange            
             var featureBitDefinitions = new List<IFeatureBitDefinition>
             {
-                new FeatureBitEfDefinition { Id = 1, OnOff = true },
-                new FeatureBitEfDefinition { Id = 2, OnOff = false },
-                new FeatureBitEfDefinition { Id = 3, OnOff = true },
+                new FeatureBitEfDefinition {Id = 1, OnOff = true},
+                new FeatureBitEfDefinition {Id = 2, OnOff = false},
+                new FeatureBitEfDefinition {Id = 3, OnOff = true},
             };
 
             // Arrange
@@ -156,9 +200,9 @@ namespace FeatureBits.Core.Test
             // MinimumAllowedPermissionLevel trumps "OnOff"
             var featureBitDefinitions = new List<IFeatureBitDefinition>
             {
-                new FeatureBitEfDefinition { Id = 1, OnOff = true, MinimumAllowedPermissionLevel = 20 },
-                new FeatureBitEfDefinition { Id = 2, OnOff = true, MinimumAllowedPermissionLevel = 30 },
-                new FeatureBitEfDefinition { Id = 3, OnOff = true, MinimumAllowedPermissionLevel = 40 },
+                new FeatureBitEfDefinition {Id = 1, OnOff = true, MinimumAllowedPermissionLevel = 20},
+                new FeatureBitEfDefinition {Id = 2, OnOff = true, MinimumAllowedPermissionLevel = 30},
+                new FeatureBitEfDefinition {Id = 3, OnOff = true, MinimumAllowedPermissionLevel = 40},
             };
 
             // Arrange
@@ -174,7 +218,7 @@ namespace FeatureBits.Core.Test
         }
 
         private static FeatureBitEvaluator SetupFeatureBitEvaluator(IFeatureBitDefinition bitDefinition)
-        {           
+        {
             return SetupFeatureBitEvaluator(new List<IFeatureBitDefinition> { bitDefinition });
         }
 
@@ -191,7 +235,7 @@ namespace FeatureBits.Core.Test
             }
 
             var repo = Substitute.For<IFeatureBitsRepo>();
-            repo.GetAllAsync().Returns(Task.FromResult((IEnumerable<IFeatureBitDefinition>) response));
+            repo.GetAllAsync().Returns(Task.FromResult((IEnumerable<IFeatureBitDefinition>)response));
             var it = new FeatureBitEvaluator(repo);
             return it;
         }

--- a/test/FeatureBits.Core.Test/SystemContextTests.cs
+++ b/test/FeatureBits.Core.Test/SystemContextTests.cs
@@ -3,10 +3,9 @@
 
 using System;
 using System.Text;
-using Dotnet.FBit;
 using Xunit;
 
-namespace Dotnet.Fbit.Tests
+namespace FeatureBits.Core.Test
 {
     public class SystemContextTests
     {
@@ -22,7 +21,7 @@ namespace Dotnet.Fbit.Tests
 
             // Assert
             Assert.Equal("foo" + Environment.NewLine, builder.ToString());
-            
+
             // Afterwards
             SystemContext.ConsoleWriteLine = null;
         }
@@ -39,7 +38,7 @@ namespace Dotnet.Fbit.Tests
 
             // Assert
             Assert.Equal("foo" + Environment.NewLine, builder.ToString());
-            
+
             // Afterwards
             SystemContext.ConsoleErrorWriteLine = null;
         }


### PR DESCRIPTION
#20 
ExcludedEnvironments should check individual environments rather than doing string.contains on the whole list.

Several other code optimizations as well.