### PR TITLE
Support net452

### DIFF
--- a/src/FeatureBits.Console/FeatureBits.Console.csproj
+++ b/src/FeatureBits.Console/FeatureBits.Console.csproj
@@ -8,13 +8,13 @@
     <Authors>microsoft</Authors>
     <PackageProjectUrl>https://github.com/Microsoft/featurebits</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/Microsoft/featurebits/blob/master/LICENSE.txt</PackageLicenseUrl>
-    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>    
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageTags>features;flags;toggling</PackageTags>
     <Version>0.1.0</Version>
     <VersionSuffix></VersionSuffix>
     <AssemblyName>dotnet-fbit</AssemblyName>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;netcoreapp2.1;net452</TargetFrameworks>
     <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.10-x64;osx.10.11-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.24-x64;opensuse.42.1-x64</RuntimeIdentifiers>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <RootNamespace>Dotnet.FBit</RootNamespace>
@@ -23,13 +23,26 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.2.1" />
     <PackageReference Include="ConsoleTableExt" Version="2.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.0.2" />
     <PackageReference Include="System.Data.SqlClient" Version="4.4.3" />
     <PackageReference Include="System.IO.Abstractions" Version="2.1.0.178" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' Or  '$(TargetFramework)' == 'netcoreapp2.0' Or '$(TargetFramework)' == 'netcoreapp2.1' ">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.0.2" />
+  </ItemGroup>
+  
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
+  
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="1.1.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="1.1.6" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.2" />
+  </ItemGroup>
+  
   <ItemGroup>
     <ProjectReference Include="..\FeatureBits.Data\FeatureBits.Data.csproj" />
   </ItemGroup>

--- a/src/FeatureBits.Core/FeatureBits.Core.csproj
+++ b/src/FeatureBits.Core/FeatureBits.Core.csproj
@@ -11,16 +11,23 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageTags>features;flags;toggling</PackageTags>
     <Version>0.1.0</Version>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.Design" Version="1.1.5" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.Design" Version="1.1.6" />
+  </ItemGroup>
+ <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="1.1.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="1.1.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.Design" Version="1.1.6" />
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FeatureBits.Data\FeatureBits.Data.csproj" />
   </ItemGroup>

--- a/src/FeatureBits.Data/EF/DesignTimeDbContextFactory.cs
+++ b/src/FeatureBits.Data/EF/DesignTimeDbContextFactory.cs
@@ -1,8 +1,12 @@
 ﻿using FeatureBits.Data.EF;
 using Microsoft.EntityFrameworkCore;
+#if !NET452
 using Microsoft.EntityFrameworkCore.Design;
 
 public class DesignTimeDbContextFactory : IDesignTimeDbContextFactory<FeatureBitsEfDbContext>
+#else
+public class DesignTimeDbContextFactory
+#endif
 {
     /// <summary>
     /// This class is used to support generation of EF migrations.

--- a/src/FeatureBits.Data/EF/FeatureBitsEfRepo.cs
+++ b/src/FeatureBits.Data/EF/FeatureBitsEfRepo.cs
@@ -70,8 +70,21 @@ namespace FeatureBits.Data.EF
 
         public async Task UpdateAsync(IFeatureBitDefinition definition)
         {
-            DbContext.Update(definition);
-            await DbContext.SaveChangesAsync();
+            try
+            {
+                DbContext.Update(definition);
+                await DbContext.SaveChangesAsync();
+            } catch (DbUpdateConcurrencyException ex)
+            {
+                if (ex.Entries.Count == 1 && ex.Entries[0].IsKeySet == false)
+                {
+                    DbContext.Add(definition);
+                    await DbContext.SaveChangesAsync();
+                } else
+                {
+                    throw ex;
+                }
+            }
         }
 
         public async Task RemoveAsync(IFeatureBitDefinition definitionToRemove)

--- a/src/FeatureBits.Data/FeatureBits.Data.csproj
+++ b/src/FeatureBits.Data/FeatureBits.Data.csproj
@@ -11,13 +11,24 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageTags>features;flags;toggling</PackageTags>
     <Version>0.1.0</Version>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="WindowsAzure.Storage" Version="9.1.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'netcoreapp2.0' Or '$(TargetFramework)' == 'netcoreapp2.1' ">
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.0.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.0.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.Design" Version="1.1.5" />
+    <PackageReference Include="WindowsAzure.Storage" Version="9.1.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="1.1.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="1.1.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.Design" Version="1.1.6" />
     <PackageReference Include="WindowsAzure.Storage" Version="9.1.1" />
   </ItemGroup>
 

--- a/test/FeatureBits.Console.Test/FeatureBits.Console.Test.csproj
+++ b/test/FeatureBits.Console.Test/FeatureBits.Console.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>    
-    <TargetFrameworks>netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp2.0;netcoreapp2.1;net452</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -10,7 +10,6 @@
     <PackageReference Include="ConsoleTableExt" Version="2.0.1" />
     <PackageReference Include="FluentAssertions" Version="5.4.1" />
     <PackageReference Include="Microsoft.CodeCoverage" Version="1.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="System.IO.Abstractions" Version="2.1.0.178" />
@@ -20,6 +19,15 @@
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'netcoreapp2.0' Or '$(TargetFramework)' == 'netcoreapp2.1' ">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.0.2" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="1.1.6" />
+  </ItemGroup>
+  
   <ItemGroup>
     <ProjectReference Include="..\..\src\FeatureBits.Console\FeatureBits.Console.csproj" />
   </ItemGroup>

--- a/test/FeatureBits.Core.Test/FeatureBits.Core.Test.csproj
+++ b/test/FeatureBits.Core.Test/FeatureBits.Core.Test.csproj
@@ -1,15 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;netcoreapp2.1;net452</TargetFrameworks>
     <SonarQubeTestProject>True</SonarQubeTestProject>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.4.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
@@ -17,6 +15,16 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
+
+<ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.1" />
+</ItemGroup>
+
+<ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="1.1.6" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.2" />
+</ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\FeatureBits.Core\FeatureBits.Core.csproj" />

--- a/test/FeatureBits.Core.Test/FeatureBits.Core.Test.csproj
+++ b/test/FeatureBits.Core.Test/FeatureBits.Core.Test.csproj
@@ -16,7 +16,7 @@
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 
-<ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' Or  '$(TargetFramework)' == 'netcoreapp2.0' Or '$(TargetFramework)' == 'netcoreapp2.1' ">
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.1" />
 </ItemGroup>

--- a/test/FeatureBits.Data.Console.Test/FeatureBits.Data.Console.Test.csproj
+++ b/test/FeatureBits.Data.Console.Test/FeatureBits.Data.Console.Test.csproj
@@ -12,8 +12,8 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="[1.1.2,2.0)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="[1.1.2,2.0)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/FeatureBits.Data.Console.Test/FeatureBits.Data.Console.Test.csproj
+++ b/test/FeatureBits.Data.Console.Test/FeatureBits.Data.Console.Test.csproj
@@ -2,13 +2,18 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;net452</TargetFrameworks>
     <UserSecretsId>05e294aa-f55d-4362-bcb7-c36835d2d3df</UserSecretsId>
   </PropertyGroup>
   
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.0.2" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="1.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/FeatureBits.Data.Test/FeatureBitEfHelper.cs
+++ b/test/FeatureBits.Data.Test/FeatureBitEfHelper.cs
@@ -14,7 +14,9 @@ namespace FeatureBits.Data.Test
             string guidDbNameForUniqueness = Guid.NewGuid().ToString();
             DbContextOptions<FeatureBitsEfDbContext> options = new DbContextOptionsBuilder<FeatureBitsEfDbContext>()
                 .UseInMemoryDatabase(guidDbNameForUniqueness)
+#if !NET452
                 .EnableSensitiveDataLogging(false)
+#endif
                 .Options;
             var dbContext = new FeatureBitsEfDbContext(options);
             return new Tuple<FeatureBitsEfDbContext, DbContextOptions<FeatureBitsEfDbContext>>(dbContext, options);

--- a/test/FeatureBits.Data.Test/FeatureBits.Data.Test.csproj
+++ b/test/FeatureBits.Data.Test/FeatureBits.Data.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;netcoreapp2.1;net452</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -12,10 +12,15 @@
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />    
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.0.2" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
   </ItemGroup>
 
+<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'netcoreapp2.0' Or '$(TargetFramework)' == 'netcoreapp2.1' ">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.0.2" />
+</ItemGroup>
+<ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="1.1.6" />
+</ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\FeatureBits.Data\FeatureBits.Data.csproj" />
   </ItemGroup>

--- a/test/FeatureBits.Data.WebApi.Test/FeatureBits.Data.WebApi.Test.csproj
+++ b/test/FeatureBits.Data.WebApi.Test/FeatureBits.Data.WebApi.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;net452</TargetFrameworks>
     <UserSecretsId>05e294aa-f55d-4362-bcb7-c36835d2d3df</UserSecretsId>
   </PropertyGroup>
 
@@ -9,15 +9,24 @@
     <Folder Include="wwwroot\" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' Or  '$(TargetFramework)' == 'netcoreapp2.0' Or '$(TargetFramework)' == 'netcoreapp2.1' ">
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.0.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.0.2" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
+    <PackageReference Include="Microsoft.AspNetCore" Version="1.1.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="1.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="1.1.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="1.1.6" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="1.1.2" />
+  </ItemGroup>
+
   <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.3" />        
+    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/FeatureBits.Data.WebApi.Test/Program.cs
+++ b/test/FeatureBits.Data.WebApi.Test/Program.cs
@@ -14,7 +14,12 @@ namespace FeatureBits.Data.WebApi.Test
         }
 
         public static IWebHost BuildWebHost(string[] args) =>
+#if NET452
+            new WebHostBuilder()
+#else
             WebHost.CreateDefaultBuilder(args)
+#endif
+
                 .UseStartup<Startup>()
                 .Build();
     }


### PR DESCRIPTION
This adds support for .NET Framework 4.5.2 to FeatureBits.

After minimal code changes, it passed all but one test. To pass that test I ended up modifying FeatureBitsEfRepo.UpdateAsync to catch an exception rather than use conditionals to compile. Let me know if you'd rather I do that the other way.