### PR TITLE
change namespace to name arg

### DIFF
--- a/src/FeatureBits.Console/CommandOptions/AddOptions.cs
+++ b/src/FeatureBits.Console/CommandOptions/AddOptions.cs
@@ -14,7 +14,7 @@ namespace Dotnet.FBit.CommandOptions
         /// <summary>
         /// Name of the feature bit to add
         /// </summary>
-        [Option('n', "namespace", Required = true, HelpText = "Name of the feature bit")]
+        [Option('n', "name", Required = true, HelpText = "Name of the feature bit")]
         public string Name { get; set; }
 
         /// <summary>


### PR DESCRIPTION
Changed the "namespace" argument to "name".

fixes #40 