### PR TITLE
Make ExactAllowedPermissionLevel mutually exclusive to MinimumAllowedPermissionLevel

### DIFF
--- a/src/FeatureBits.Core/FeatureBitEvaluator.cs
+++ b/src/FeatureBits.Core/FeatureBitEvaluator.cs
@@ -107,10 +107,9 @@ namespace FeatureBits.Core
             {
                 result = EvaluateEnvironmentBasedFeatureState(bitDef);
             }
-            else if (currentUsersPermissionLevel > 0 &&
-                     bitDef.ExactAllowedPermissionLevel == currentUsersPermissionLevel)
+            else if (currentUsersPermissionLevel > 0 && bitDef.ExactAllowedPermissionLevel > 0)
             {
-                result = true;
+                result = bitDef.ExactAllowedPermissionLevel == currentUsersPermissionLevel;
             }
             else if (bitDef.MinimumAllowedPermissionLevel > 0)
             {

--- a/src/FeatureBits.Data/IFeatureBitDefinition.cs
+++ b/src/FeatureBits.Data/IFeatureBitDefinition.cs
@@ -34,6 +34,7 @@ namespace FeatureBits.Data
 
         /// <summary>
         /// The exact allowed permission level for this feature to be enabled.
+        /// This takes precedent over MinimumAllowedPermissionLevel
         /// </summary>
         int? ExactAllowedPermissionLevel { get; set; }
 

--- a/test/FeatureBits.Core.Test/FeatureBitEvaluatorTests.cs
+++ b/test/FeatureBits.Core.Test/FeatureBitEvaluatorTests.cs
@@ -149,6 +149,28 @@ namespace FeatureBits.Core.Test
         }
 
         [Theory]
+        [InlineData(30, 20, 20, false)]
+        [InlineData(10, 10, 20, true)]
+        public void It_prefers_an_exact_Role_over_a_minimum_Role_FeatureBit(int userPermission, int exactAllowedPermission, int minimumAllowedPermission, bool expectedResult)
+        {
+            // Arrange
+            int bitId = 0;
+            var it = SetupFeatureBitEvaluator(new FeatureBitEfDefinition
+            {
+                Id = bitId,
+                OnOff = false,
+                ExactAllowedPermissionLevel = exactAllowedPermission,
+                MinimumAllowedPermissionLevel = minimumAllowedPermission
+            });
+
+            // Act
+            var result = it.IsEnabled(bitId, userPermission);
+
+            // Assert
+            result.Should().Be(expectedResult);
+        }
+
+        [Theory]
         [InlineData(20)]
         [InlineData(10)]
         [InlineData(1)]


### PR DESCRIPTION
If ExactAllowedPermissionLevel is set do not evaluate MinimumAllowedPermissionLevel